### PR TITLE
Fix missing $sso_user_info in create_wp_user()

### DIFF
--- a/avoine-sso-login.php
+++ b/avoine-sso-login.php
@@ -5,7 +5,7 @@
  * Plugin URI: http://dude.fi
  * Author: Digitoimisto Dude Oy
  * Author URI: http://dude.fi
- * Version: 2.0.0
+ * Version: 2.0.1
  * License: GPLv3
  *
  * @Author:             Digitoimisto Dude Oy (https://dude.fi)

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "plugin"
   ],
   "license": "GPL-3.0+",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "authors": [{
     "name": "Timi Wahalahti",
     "email": "timi@dude.fi",

--- a/inc/user.php
+++ b/inc/user.php
@@ -178,7 +178,15 @@ function create_wp_user( $sso_user = null ) {
     return false;
   }
 
-  $userdata = get_user_data_for_wp( $sso_user );
+  // get all user information from SSO server
+  $sso_user_info = get_sso_user_information( $sso_user->id );
+
+  // bail if we cant get all information
+  if ( empty( $sso_user_info ) ) {
+    return false;
+  }
+
+  $userdata = get_user_data_for_wp( $sso_user, $sso_user_info );
   if ( ! $userdata ) {
     return false;
   }
@@ -227,14 +235,17 @@ function create_wp_user( $sso_user = null ) {
  * Get data used for creating and updating WP shadow user.
  *
  * @since  2.0.0
- * @param  object $sso_user SSO user.
- * @return boolean|array    Array containing data for WP user.
+ * @param  object $sso_user      SSO user.
+ * @param  array  $sso_user_info SSO user info from SSO server.
+ * @return boolean|array         Array containing data for WP user.
  */
-function get_user_data_for_wp( $sso_user ) {
+function get_user_data_for_wp( $sso_user, $sso_user_info = [] ) {
   $userdata = [];
 
   // get all user information from SSO server
-  $sso_user_info = get_sso_user_information( $sso_user->id );
+  if ( empty( $sso_user_info ) ) {
+    $sso_user_info = get_sso_user_information( $sso_user->id );
+  }
 
   // bail if we cant get all information
   if ( empty( $sso_user_info ) ) {


### PR DESCRIPTION
Attempt for a minimal impact fix:

$sso_user_info was undefined in create_wp_user(), so we'll fetch it before calling get_user_data_for_wp(). For backwards compatibility get_user_data_for_wp() still accepts empty $sso_user_info (not sure if that's really necessary, but it doesn't hurt I guess).