### PR TITLE
Fix invalid REQUEST_URI check in capture_sso_logout

### DIFF
--- a/avoine-sso-login.php
+++ b/avoine-sso-login.php
@@ -5,7 +5,7 @@
  * Plugin URI: http://dude.fi
  * Author: Digitoimisto Dude Oy
  * Author URI: http://dude.fi
- * Version: 2.0.1
+ * Version: 2.0.2
  * License: GPLv3
  *
  * @Author:             Digitoimisto Dude Oy (https://dude.fi)

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "plugin"
   ],
   "license": "GPL-3.0+",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "authors": [{
     "name": "Timi Wahalahti",
     "email": "timi@dude.fi",

--- a/hooks/auth-flow.php
+++ b/hooks/auth-flow.php
@@ -99,7 +99,7 @@ function capture_sso_logout() {
     return;
   }
 
-  if ( ! isset( $_SERVER['REQUEST_URI']['path'] ) ) {
+  if ( ! isset( $_SERVER['REQUEST_URI'] ) ) {
     return;
   }
 


### PR DESCRIPTION
Having a REQUEST_URI check makes sense, but there is no ['path'], so as it was it never passed. At least not in environments I'm familiar with :)